### PR TITLE
Store intermediate message state.

### DIFF
--- a/apps/blunt/lib/blunt.ex
+++ b/apps/blunt/lib/blunt.ex
@@ -2,7 +2,7 @@ defmodule Blunt do
   use Application
 
   def start(_type, _args) do
-    [Blunt.DispatchContext.Shipper]
+    [Blunt.DispatchContext.Shipper, Blunt.Message.State]
     |> Supervisor.start_link(strategy: :one_for_one, name: Blunt.Supervisor)
   end
 

--- a/apps/blunt/lib/blunt/command.ex
+++ b/apps/blunt/lib/blunt/command.ex
@@ -4,7 +4,7 @@ defmodule Blunt.Command do
 
   defmacro __using__(opts) do
     opts =
-      [require_all_fields?: true, keep_discarded_data: true]
+      [require_all_fields?: true]
       |> Keyword.merge(opts)
       |> Keyword.put(:dispatch?, true)
       |> Keyword.put(:message_type, :command)

--- a/apps/blunt/lib/blunt/dispatch_strategy/default.ex
+++ b/apps/blunt/lib/blunt/dispatch_strategy/default.ex
@@ -43,6 +43,7 @@ defmodule Blunt.DispatchStrategy.Default do
   def dispatch(%{message_type: :query} = context) do
     bindings = Query.bindings(context)
     filter_list = Query.create_filter_list(context)
+
     pipeline = PipelineResolver.get_pipeline!(context, QueryHandler)
 
     context =

--- a/apps/blunt/lib/blunt/message.ex
+++ b/apps/blunt/lib/blunt/message.ex
@@ -27,7 +27,8 @@ defmodule Blunt.Message do
     PrimaryKey,
     Schema,
     Schema.Fields,
-    Version
+    Version,
+    State
   }
 
   defmodule Error do
@@ -70,9 +71,7 @@ defmodule Blunt.Message do
       @behaviour Blunt.Message
       @before_compile Blunt.Message
 
-      if opts[:keep_discarded_data] do
-        @schema_fields {:discarded_data, :map, required: false, internal: true, virtual: true}
-      end
+      @schema_fields {:__blunt_id, :binary_id, required: false, internal: true, virtual: true}
 
       @impl true
       def handle_validate(changeset, _opts), do: changeset
@@ -152,4 +151,10 @@ defmodule Blunt.Message do
 
   @doc false
   defdelegate compile_start(message_module), to: Blunt.Message.Compilation
+
+  def user_supplied_fields(%{__blunt_id: id}),
+    do: State.get(id, :user_supplied_fields, [])
+
+  def discarded_data(%{__blunt_id: id}),
+    do: State.get(id, :discarded_data, [])
 end

--- a/apps/blunt/lib/blunt/message/constructor.ex
+++ b/apps/blunt/lib/blunt/message/constructor.ex
@@ -3,7 +3,7 @@ defmodule Blunt.Message.Constructor do
 
   alias Ecto.Changeset
   alias __MODULE__, as: Constructor
-  alias Blunt.Message.{Documentation, Input, State}
+  alias Blunt.Message.{Documentation, Input, Options}
   alias Blunt.Message.Changeset, as: MessageChangeset
 
   defmacro register(opts) do
@@ -71,7 +71,8 @@ defmodule Blunt.Message.Constructor do
     overrides = Input.normalize(overrides, module)
     input = Map.merge(values, overrides)
 
-    with {:ok, message} <- input |> module.changeset(opts) |> handle_changeset() do
+    with {:ok, opts} <- Options.Parser.parse_message_opts(module, opts),
+         {:ok, message} <- input |> module.changeset(opts) |> handle_changeset() do
       {:ok, module.after_validate(message)}
     end
   end

--- a/apps/blunt/lib/blunt/message/state.ex
+++ b/apps/blunt/lib/blunt/message/state.ex
@@ -1,0 +1,55 @@
+defmodule Blunt.Message.State do
+  use DynamicSupervisor
+
+  def start_link(opts) do
+    DynamicSupervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def put(%{__blunt_id: id}, value) when is_map(value),
+    do: put(id, value)
+
+  def put(id, value) when is_map(value) do
+    id
+    |> get_or_start_server()
+    |> __MODULE__.Server.put(value)
+  end
+
+  def put(%{__blunt_id: id}, key, value) when is_atom(key),
+    do: put(id, key, value)
+
+  def put(id, key, value) when is_atom(key) do
+    id
+    |> get_or_start_server()
+    |> __MODULE__.Server.put(key, value)
+  end
+
+  def get(%{__blunt_id: id}),
+    do: get(id)
+
+  def get(id) do
+    id
+    |> get_or_start_server()
+    |> __MODULE__.Server.get()
+  end
+
+  def get(%{__blunt_id: id}, key, default \\ nil) when is_atom(key) do
+    id
+    |> get()
+    |> Map.get(key, default)
+  end
+
+  defp get_or_start_server(id) do
+    spec = Supervisor.child_spec({__MODULE__.Server, id}, restart: :transient)
+
+    case DynamicSupervisor.start_child(__MODULE__, spec) do
+      {:ok, pid} -> pid
+      {:ok, pid, _} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+end

--- a/apps/blunt/lib/blunt/message/state/server.ex
+++ b/apps/blunt/lib/blunt/message/state/server.ex
@@ -1,0 +1,34 @@
+defmodule Blunt.Message.State.Server do
+  @timeout :timer.minutes(1)
+  use GenServer, restart: :transient
+
+  def start_link(id) do
+    name = {:global, inspect(__MODULE__) <> "/" <> id}
+    GenServer.start_link(__MODULE__, %{id: id}, name: name)
+  end
+
+  def get(pid), do: GenServer.call(pid, :get)
+
+  def put(pid, key, value),
+    do: GenServer.call(pid, {:put, key, value})
+
+  def put(pid, value) when is_map(value),
+    do: GenServer.call(pid, {:put, value})
+
+  @impl true
+  def init(state), do: {:ok, state}
+
+  @impl true
+  def handle_call(:get, _from, state),
+    do: {:reply, state, state, @timeout}
+
+  def handle_call({:put, value}, _from, state) do
+    new_state = Map.merge(state, value)
+    {:reply, new_state, new_state, @timeout}
+  end
+
+  def handle_call({:put, key, value}, _from, state) do
+    new_state = Map.put(state, key, value)
+    {:reply, new_state, new_state, @timeout}
+  end
+end

--- a/apps/blunt/lib/blunt/query.ex
+++ b/apps/blunt/lib/blunt/query.ex
@@ -64,7 +64,7 @@ defmodule Blunt.Query do
 
     filter_map
     |> Map.from_struct()
-    |> Map.delete(:discarded_data)
+    |> Map.delete(:__blunt_id)
     |> reject_nil_filters(opts)
   end
 

--- a/apps/blunt/lib/blunt/testing/factories/dispatch_strategy.ex
+++ b/apps/blunt/lib/blunt/testing/factories/dispatch_strategy.ex
@@ -22,7 +22,6 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
         dispatch_opts
         |> Keyword.put(:dispatched_from, :ex_machina)
         |> Keyword.update(:return, :context, &Function.identity/1)
-        |> Keyword.put(:user_supplied_fields, Metadata.field_names(module))
 
       case module.dispatch({:ok, message}, dispatch_opts) do
         {:error, %DispatchContext{} = context} ->

--- a/apps/blunt/lib/blunt/testing/factories/dispatch_strategy.ex
+++ b/apps/blunt/lib/blunt/testing/factories/dispatch_strategy.ex
@@ -7,7 +7,6 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
       defexception [:message]
     end
 
-    alias Blunt.Message.Metadata
     alias Blunt.{DispatchContext, Message}
 
     def handle_dispatch(message, opts),

--- a/apps/blunt/test/blunt/command_test.exs
+++ b/apps/blunt/test/blunt/command_test.exs
@@ -1,6 +1,7 @@
 defmodule Blunt.CommandTest do
   use ExUnit.Case, async: true
 
+  alias Blunt.Message
   alias Blunt.Message.Metadata
   alias Blunt.CommandTest.Protocol
   alias Blunt.{Command, DispatchContext}
@@ -25,19 +26,12 @@ defmodule Blunt.CommandTest do
   describe "discarded data" do
     alias Protocol.DispatchWithPipeline
 
-    test "field is defined" do
-      assert {:discarded_data, :map, [required: false, internal: true, virtual: true]} =
-               DispatchWithPipeline
-               |> Metadata.fields()
-               |> Enum.find(&match?({:discarded_data, _, _}, &1))
-    end
-
-    test "data is preserved" do
+    test "data is preserved in state" do
       attrs = %{name: "chris", poop: :yum}
 
       {:ok, command} = DispatchWithPipeline.new(attrs)
 
-      assert %{discarded_data: %{"poop" => :yum}} = command
+      assert %{discarded_data: %{"poop" => :yum}} = Message.State.get(command)
 
       assert {:ok, dispatch_context} = DispatchWithPipeline.dispatch(command, reply_to: self(), return: :context)
 

--- a/apps/blunt/test/blunt/dispatch_context_test.exs
+++ b/apps/blunt/test/blunt/dispatch_context_test.exs
@@ -22,8 +22,6 @@ defmodule Blunt.DispatchContextTest do
         |> DiscardedDataCommand.dispatch(return: :context)
 
       assert %{"dog" => "maize"} = DispatchContext.discarded_data(context)
-      assert command = DispatchContext.get_message(context)
-      assert command.discarded_data == %{}
     end
   end
 

--- a/apps/blunt/test/blunt/message/metadata_test.exs
+++ b/apps/blunt/test/blunt/message/metadata_test.exs
@@ -12,7 +12,7 @@ defmodule Blunt.Message.MetadataTest do
 
   describe "virutal fields" do
     test "field names" do
-      assert [:calculated] == Metadata.field_names(MyMessage, :virtual)
+      assert [:__blunt_id, :calculated] == Metadata.field_names(MyMessage, :virtual)
     end
 
     test "are not json serialized" do
@@ -25,8 +25,7 @@ defmodule Blunt.Message.MetadataTest do
 
       refute Map.has_key?(rehydrated_map, "calculated")
 
-      assert {:ok, %MyMessage{dog: :maize, name: "chris", calculated: nil}} ==
-               MyMessage.new(rehydrated_map)
+      assert {:ok, %MyMessage{dog: :maize, name: "chris", calculated: nil}} = MyMessage.new(rehydrated_map)
     end
   end
 end

--- a/apps/blunt/test/blunt/message_test.exs
+++ b/apps/blunt/test/blunt/message_test.exs
@@ -30,7 +30,7 @@ defmodule Blunt.MessageTest do
   test "internal fields are never required" do
     alias Protocol.MessageWithInternalField, as: Msg
 
-    assert [:id] == Metadata.field_names(Msg)
+    assert [:__blunt_id, :id] == Metadata.field_names(Msg)
 
     required_fields = Metadata.field_names(Msg, :required)
     refute Enum.member?(required_fields, :id)

--- a/apps/blunt_absinthe/lib/blunt/absinthe/field.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/field.ex
@@ -135,13 +135,10 @@ defmodule Blunt.Absinthe.Field do
     end
   end
 
-  def put_dispatch_opts(opts, operation, args) do
-    user_supplied_fields = args |> Map.keys() |> Enum.sort()
-
+  def put_dispatch_opts(opts, operation, _args) do
     opts
     |> Keyword.put(:ship, false)
     |> Keyword.put(:return, :context)
     |> Keyword.put(operation, true)
-    |> Keyword.put(:user_supplied_fields, user_supplied_fields)
   end
 end

--- a/apps/blunt_data/lib/blunt/data/factories/factory.ex
+++ b/apps/blunt_data/lib/blunt/data/factories/factory.ex
@@ -141,30 +141,7 @@ defmodule Blunt.Data.Factories.Factory do
 
   defp debug(%{final_message: final_message, opts: opts} = factory, :final_message) do
     label = ANSI.format([:green, "deliver"])
-
-    final_message =
-      cond do
-        is_map(final_message) ->
-          case Keyword.get(opts, :discarded_data, :hide) do
-            value when value in [:hide, false] ->
-              case Map.get(final_message, :discarded_data) do
-                nil ->
-                  final_message
-
-                _ ->
-                  Map.put(final_message, :discarded_data, "configure the factory option 'discarded_data: true' to show")
-              end
-
-            _ ->
-              final_message
-          end
-
-        true ->
-          final_message
-      end
-
     debug(final_message, label, opts)
-
     factory
   end
 

--- a/apps/blunt_ddd/lib/blunt/bounded_context/proxy.ex
+++ b/apps/blunt_ddd/lib/blunt/bounded_context/proxy.ex
@@ -145,7 +145,6 @@ defmodule Blunt.BoundedContext.Proxy do
       |> Keyword.merge(proxy_opts)
       |> Keyword.merge(internal_opts)
       |> Keyword.put(:dispatched_from, :bounded_context)
-      |> Keyword.put(:user_supplied_fields, user_supplied_fields(values))
       |> Keyword.pop(:field_values, [])
 
     field_values = Enum.into(field_values, %{})
@@ -185,13 +184,4 @@ defmodule Blunt.BoundedContext.Proxy do
       {:error, error} -> raise DispatchError, message: error
     end
   end
-
-  defp user_supplied_fields(list) when is_list(list),
-    do: Keyword.keys(list)
-
-  defp user_supplied_fields(struct) when is_struct(struct),
-    do: user_supplied_fields(Map.from_struct(struct))
-
-  defp user_supplied_fields(map) when is_map(map),
-    do: Map.keys(map)
 end

--- a/apps/blunt_ddd/lib/blunt/command/events.ex
+++ b/apps/blunt_ddd/lib/blunt/command/events.ex
@@ -57,7 +57,7 @@ defmodule Blunt.Command.Events do
         {:created_at, _, _} ->
           nil
 
-        {:discarded_data, _, _} ->
+        {:__blunt_id, _, _} ->
           nil
 
         {name, type, opts} ->

--- a/apps/blunt_ddd/lib/blunt/domain_event.ex
+++ b/apps/blunt_ddd/lib/blunt/domain_event.ex
@@ -35,7 +35,7 @@ defmodule Blunt.DomainEvent do
           opts
           |> Keyword.get(:drop, [])
           |> List.wrap()
-          |> Kernel.++([:discarded_data])
+          |> Kernel.++([:__blunt_id])
 
         command_module
         |> Blunt.Message.Metadata.fields()

--- a/apps/blunt_ddd/lib/blunt/value_object/equality.ex
+++ b/apps/blunt_ddd/lib/blunt/value_object/equality.ex
@@ -11,8 +11,11 @@ defmodule Blunt.ValueObject.Equality do
   def equals?(_module, nil, _), do: false
   def equals?(_module, _, nil), do: false
 
-  def equals?(module, %{__struct__: module} = left, %{__struct__: module} = right),
-    do: Map.equal?(left, right)
+  def equals?(module, %{__struct__: module} = left, %{__struct__: module} = right) do
+    left = Map.delete(left, :__blunt_id)
+    right = Map.delete(right, :__blunt_id)
+    Map.equal?(left, right)
+  end
 
   def equals?(module, _left, _right) do
     Logger.warn("#{inspect(module)}.equals? requires two #{inspect(module)} structs")

--- a/apps/blunt_ddd/test/blunt/domain_event_test.exs
+++ b/apps/blunt_ddd/test/blunt/domain_event_test.exs
@@ -24,7 +24,7 @@ defmodule Blunt.DomainEventTest do
   end
 
   test "EventDerivedFromCommand has fields from CommandToTestDerivation" do
-    expected_fields = Metadata.field_names(CommandToTestDerivation) -- [:discarded_data]
+    expected_fields = Metadata.field_names(CommandToTestDerivation)
     actual_fields = Metadata.field_names(EventDerivedFromCommand)
 
     assert Enum.all?(expected_fields, &Enum.member?(actual_fields, &1))


### PR DESCRIPTION
This is to explore the idea of storing intermediate data such as
user_supplied_fields and discarded_data in a gen_server while when the
message is constructed.

The server will timeout after 60 seconds; cleaning up after itself.