### PR TITLE
Support Absinthe nested changeset validation errors

### DIFF
--- a/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
@@ -27,7 +27,13 @@ defmodule Blunt.Absinthe.AbsintheErrors do
         Enum.map(messages, fn message -> [message: message] end) ++ acc
 
       {key, messages}, acc when is_list(messages) or is_map(messages) ->
-        Enum.map(messages, fn message -> [message: "#{key} #{message}"] end) ++ acc
+        Enum.map(messages, fn
+          {field, messages} ->
+            [message: "#{key}.#{field} #{messages |> Enum.join(",")}"]
+
+          message ->
+            [message: "#{key} #{message}"]
+        end) ++ acc
 
       {key, message}, acc when is_binary(message) ->
         [[message: "#{key} #{message}"] | acc]

--- a/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
@@ -29,14 +29,15 @@ defmodule Blunt.Absinthe.AbsintheErrors do
       {key, messages}, acc when is_list(messages) or is_map(messages) ->
         Enum.flat_map(leaves_with_path(messages, [key]), fn
           {path, messages} ->
+            path = Enum.map(path, &to_string/1)
             label = Enum.join(path, ".")
             message = messages |> List.wrap() |> Enum.join(", ")
 
-            [[message: "#{label} #{message}"]]
+            [[message: "#{label} #{message}", path: path]]
         end) ++ acc
 
       {key, message}, acc when is_binary(message) ->
-        [[message: "#{key} #{message}"] | acc]
+        [[message: "#{key} #{message}", path: [key]] | acc]
     end)
     |> Enum.map(&Keyword.merge(&1, extra_properties))
   end

--- a/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
@@ -42,7 +42,7 @@ defmodule Blunt.Absinthe.AbsintheErrors do
     |> Enum.map(&Keyword.merge(&1, extra_properties))
   end
 
-  def leaves_with_path(input, path \\ []) do
+  defp leaves_with_path(input, path \\ []) do
     Enum.flat_map(input, fn {key, value} ->
       full = [key | path]
       if is_map(value), do: leaves_with_path(value, full), else: [{Enum.reverse(full), value}]

--- a/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/absinthe_errors.ex
@@ -29,7 +29,7 @@ defmodule Blunt.Absinthe.AbsintheErrors do
       {key, messages}, acc when is_list(messages) or is_map(messages) ->
         Enum.map(messages, fn
           {field, messages} ->
-            [message: "#{key}.#{field} #{messages |> Enum.join(",")}"]
+            [message: "#{key}.#{field} #{messages |> Enum.join(", ")}"]
 
           message ->
             [message: "#{key} #{message}"]

--- a/apps/blunt_absinthe/lib/blunt/absinthe/field.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/field.ex
@@ -86,6 +86,8 @@ defmodule Blunt.Absinthe.Field do
   def dispatch_and_resolve(operation, message_module, query_opts, parent, args, resolution) do
     context_configuration = DispatchContextConfiguration.configure(message_module, resolution)
 
+    input_object = Keyword.get(query_opts, :input_object, false) || Keyword.get(query_opts, :input_object?, false)
+
     args = Map.get(args, :input, args)
 
     opts =
@@ -112,6 +114,8 @@ defmodule Blunt.Absinthe.Field do
         return_value
 
       {:error, errors} when is_map(errors) ->
+        errors = if input_object, do: %{input: errors}, else: errors
+
         {:error, AbsintheErrors.format(errors)}
 
       {:ok, %Context{} = context} ->

--- a/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
+++ b/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
@@ -85,7 +85,7 @@ defmodule Blunt.Absinthe.MutationTest do
                variables: %{
                  "name" => "chris",
                  "gender" => "MALE",
-                 "address" => %{"line1" => "--"}
+                 "address" => %{"line1" => "10"}
                }
              )
 
@@ -137,6 +137,6 @@ defmodule Blunt.Absinthe.MutationTest do
                }
              )
 
-    assert message =~ "address.line1 should be at least 3 character(s)"
+    assert message =~ "address.line1 should start with a number, should be at least 3 character(s)"
   end
 end

--- a/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
+++ b/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
@@ -14,6 +14,10 @@ defmodule Blunt.Absinthe.MutationTest do
           id
           name
           gender
+          address {
+            line1
+            line2
+          }
         }
       }
       """
@@ -34,9 +38,11 @@ defmodule Blunt.Absinthe.MutationTest do
 
   test "can create a person", %{query: query} do
     assert {:ok, %{data: %{"createPerson" => person}}} =
-             Absinthe.run(query, Schema, variables: %{"name" => "chris", "gender" => "MALE"})
+             Absinthe.run(query, Schema,
+               variables: %{"name" => "chris", "gender" => "MALE", "address" => %{"line1" => "42 Infinity Ave"}}
+             )
 
-    assert %{"id" => id, "name" => "chris", "gender" => "MALE"} = person
+    assert %{"id" => id, "name" => "chris", "gender" => "MALE", "address" => %{"line1" => "42 Infinity Ave"}} = person
     assert {:ok, _} = UUID.info(id)
   end
 

--- a/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
+++ b/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
@@ -99,6 +99,9 @@ defmodule Blunt.Absinthe.MutationTest do
              },
              gender: %{
                type: :gender
+             },
+             address: %{
+               type: :address_input
              }
            } = fields
   end

--- a/apps/blunt_absinthe/test/support/address.ex
+++ b/apps/blunt_absinthe/test/support/address.ex
@@ -1,0 +1,13 @@
+defmodule Blunt.Absinthe.Test.Address do
+  use Blunt.ValueObject
+  import Ecto.Changeset
+
+  field :line1, :string, required: true
+  field :line2, :string
+
+  @impl true
+  def handle_validate(changeset, _opts) do
+    changeset
+    |> validate_length(:line1, min: 3)
+  end
+end

--- a/apps/blunt_absinthe/test/support/address.ex
+++ b/apps/blunt_absinthe/test/support/address.ex
@@ -9,5 +9,6 @@ defmodule Blunt.Absinthe.Test.Address do
   def handle_validate(changeset, _opts) do
     changeset
     |> validate_length(:line1, min: 3)
+    |> validate_format(:line1, ~r/(\d)+.*/, message: "should start with a number")
   end
 end

--- a/apps/blunt_absinthe/test/support/create_person.ex
+++ b/apps/blunt_absinthe/test/support/create_person.ex
@@ -8,6 +8,7 @@ defmodule Blunt.Absinthe.Test.CreatePerson do
 
   field :name, :string
   field :gender, :enum, values: Person.genders(), default: :not_sure
+  field :address, Blunt.Absinthe.Test.Address, required: false
 
   internal_field :id, :binary_id, desc: "Id is set internally. Setting it will have no effect"
 

--- a/apps/blunt_absinthe/test/support/create_person_handler.ex
+++ b/apps/blunt_absinthe/test/support/create_person_handler.ex
@@ -8,7 +8,11 @@ defmodule Blunt.Absinthe.Test.CreatePersonHandler do
   def handle_dispatch(command, _context) do
     command
     |> Map.from_struct()
+    |> Map.update!(:address, &to_map/1)
     |> Person.changeset()
     |> Repo.insert()
   end
+
+  defp to_map(nil), do: nil
+  defp to_map(value), do: Map.from_struct(value)
 end

--- a/apps/blunt_absinthe/test/support/get_person.ex
+++ b/apps/blunt_absinthe/test/support/get_person.ex
@@ -9,5 +9,5 @@ defmodule Blunt.Absinthe.Test.GetPerson do
 
   field :error_out, :boolean, default: false
 
-  binding :person, BluntBoundedContext.QueryTest.ReadModel.Person
+  binding :person, Blunt.Absinthe.Test.ReadModel.Person
 end

--- a/apps/blunt_absinthe/test/support/read_model.ex
+++ b/apps/blunt_absinthe/test/support/read_model.ex
@@ -9,12 +9,23 @@ defmodule Blunt.Absinthe.Test.ReadModel do
     schema "people" do
       field :name, :string
       field :gender, Ecto.Enum, values: @genders, default: :not_sure
+
+      embeds_one :address, Address, primary_key: false do
+        field :line1, :string
+        field :line2, :string
+      end
     end
 
     def changeset(person \\ %__MODULE__{}, attrs) do
       person
       |> Ecto.Changeset.cast(attrs, [:id, :name, :gender])
       |> Ecto.Changeset.validate_required([:id, :gender])
+      |> Ecto.Changeset.cast_embed(:address, with: &address_changeset/2)
+    end
+
+    def address_changeset(address, attrs) do
+      address
+      |> Ecto.Changeset.cast(attrs, [:line1, :line2])
     end
   end
 end

--- a/apps/blunt_absinthe/test/support/schema_types.ex
+++ b/apps/blunt_absinthe/test/support/schema_types.ex
@@ -2,7 +2,7 @@ defmodule Blunt.Absinthe.Test.SchemaTypes do
   use Blunt.Absinthe
   use Absinthe.Schema.Notation
 
-  alias Blunt.Absinthe.Test.{CreatePerson, GetPerson, UpdatePerson, Dog}
+  alias Blunt.Absinthe.Test.{CreatePerson, GetPerson, UpdatePerson, Address, Dog}
 
   derive_enum :gender, {CreatePerson, :gender}
 
@@ -10,9 +10,12 @@ defmodule Blunt.Absinthe.Test.SchemaTypes do
     field :id, :id
     field :name, :string
     field :gender, :gender
+    field :address, :address
   end
 
   derive_object(:dog, Dog)
+  derive_object(:address, Address)
+  derive_mutation_input Address
 
   object :person_queries do
     derive_query GetPerson, :person,
@@ -24,7 +27,7 @@ defmodule Blunt.Absinthe.Test.SchemaTypes do
   derive_mutation_input(UpdatePerson, arg_types: [gender: :gender])
 
   object :person_mutations do
-    derive_mutation CreatePerson, :person, arg_types: [gender: :gender]
+    derive_mutation CreatePerson, :person, arg_types: [gender: :gender, address: :address_input]
     derive_mutation UpdatePerson, :person, input_object: true
   end
 end

--- a/apps/blunt_absinthe/test/support/schema_types.ex
+++ b/apps/blunt_absinthe/test/support/schema_types.ex
@@ -24,7 +24,7 @@ defmodule Blunt.Absinthe.Test.SchemaTypes do
       ]
   end
 
-  derive_mutation_input(UpdatePerson, arg_types: [gender: :gender])
+  derive_mutation_input(UpdatePerson, arg_types: [gender: :gender, address: :address_input])
 
   object :person_mutations do
     derive_mutation CreatePerson, :person, arg_types: [gender: :gender, address: :address_input]

--- a/apps/blunt_absinthe/test/support/update_person.ex
+++ b/apps/blunt_absinthe/test/support/update_person.ex
@@ -5,4 +5,5 @@ defmodule Blunt.Absinthe.Test.UpdatePerson do
   field :id, :binary_id
   field :name, :string
   field :gender, :enum, values: Person.genders(), required: false
+  field :address, Blunt.Absinthe.Test.Address, required: false
 end


### PR DESCRIPTION
`Blunt.Absinthe.AbsintheErrors.format/2`: Add support for formatting error tuple from nested changeset validation errors.

i.e. `{:field, ["should be X", "can't be Y"]}`