### PR TITLE
Fix factory prop with single key

### DIFF
--- a/apps/blunt_data/lib/blunt/data/factories/values/prop.ex
+++ b/apps/blunt_data/lib/blunt/data/factories/values/prop.ex
@@ -21,11 +21,6 @@ defmodule Blunt.Data.Factories.Values.Prop do
             value = Factory.log_value(current_factory, [], field, lazy, "prop")
             put_values(acc, field, value, opts)
 
-          [path] ->
-            value = get_in(acc, Access.key(path))
-            value = Factory.log_value(current_factory, value, field, lazy, "prop")
-            put_values(acc, field, value, opts)
-
           [head | rest] ->
             # ensure that the first key in the path is not nil
             acc =

--- a/apps/blunt_data/test/blunt/data/factories/factory_test.exs
+++ b/apps/blunt_data/test/blunt/data/factories/factory_test.exs
@@ -9,17 +9,18 @@ defmodule Blunt.Data.Factories.FactoryTest do
     prop :name, fn %{name: name} -> name end
   end
 
-  test "error indicates what prop failed evaluatation" do
+  test "error indicates what prop failed evaluation" do
     exception =
       assert_raise(ValueError, fn ->
         build(:error_env)
       end)
 
-    """
-    factory: error_env
-    prop: :name
+    assert ValueError.message(exception) == """
 
-    %FunctionClauseError{module: Blunt.Data.Factories.FactoryTest, function: :\"-error_env_factory/1-fun-0-\", arity: 1, kind: nil, args: nil, clauses: nil}
-    """ == ValueError.message(exception)
+           factory: error_env
+           prop: :name
+
+           %FunctionClauseError{module: Blunt.Data.Factories.FactoryTest, function: :\"-error_env_factory/1-fun-0-\", arity: 1, kind: nil, args: nil, clauses: nil}
+           """
   end
 end

--- a/apps/blunt_data/test/blunt/data/factories_test.exs
+++ b/apps/blunt_data/test/blunt/data/factories_test.exs
@@ -46,12 +46,20 @@ defmodule Blunt.Data.FactoriesTest do
       prop :name, [:person, :name]
     end
 
+    factory FactoryWithValuesMessage, as: :single_key_prop do
+      const :dog, "corn"
+      prop :id, [:person, :id]
+      prop :name, [:dog]
+    end
+
     test "factory values" do
       id = UUID.uuid4()
 
       person = %{id: id, name: "chris", dog: "maize"}
 
       assert %FactoryWithValuesMessage{id: ^id, name: "chris", dog: "maize"} = build(:my_message, person: person)
+
+      assert %FactoryWithValuesMessage{id: ^id, name: "corn", dog: "corn"} = build(:single_key_prop, person: person)
     end
   end
 

--- a/apps/opentelemetry_blunt/test/opentelemetry_blunt_test.exs
+++ b/apps/opentelemetry_blunt/test/opentelemetry_blunt_test.exs
@@ -69,15 +69,14 @@ defmodule OpentelemetryBluntTest do
       assert_receive(
         {:span,
          span(
-           name: "dispatch",
+           name: "blunt.dispatch",
            attributes: attributes,
            parent_span_id: :undefined,
            status: :undefined
          )}
       )
 
-      :otel_attributes.map(attributes)
-      |> IO.inspect(label: "~/code/personal/blunt/apps/opentelemetry_blunt/test/opentelemetry_blunt_test.exs:79")
+      assert %{message_module: OpentelemetryBluntTest.MyCommand} = :otel_attributes.map(attributes)
     end
   end
 end


### PR DESCRIPTION
Fixes `FunctionClauseError` when prop used with path with a single key.

Dialyzer correctly emitted a warning: 

```elixir
The call 'Elixir.Kernel':get_in
         (_acc@1 :: any(),
          fun(('get' | 'get_and_update', map(), fun((_) -> any())) ->
                  'pop' | [{atom(), _}] | {_, [{_, _}] | map()} | map())) will never return since the success typing is 
         (any(),
          nonempty_maybe_improper_list()) -> 
          any() and the contract is 
          ('Elixir.Access':t(), [term(), ...]) -> term()
```

Plus a couple other test fixups.