### PR TITLE
Allow input object to be required

### DIFF
--- a/apps/blunt_absinthe/lib/blunt/absinthe/field.ex
+++ b/apps/blunt_absinthe/lib/blunt/absinthe/field.ex
@@ -78,11 +78,17 @@ defmodule Blunt.Absinthe.Field do
   def args(:absinthe_mutation, message_module, opts) do
     input_object = Keyword.get(opts, :input_object, false)
     input_object? = Keyword.get(opts, :input_object?, false)
+    required? = Keyword.get(opts, :required, false)
 
     case input_object || input_object? do
       true ->
         field_name = :"#{Field.name(message_module, opts)}_input"
-        [quote(do: arg(:input, unquote(field_name)))]
+
+        if required? do
+          [quote(do: arg(:input, non_null(unquote(field_name))))]
+        else
+          [quote(do: arg(:input, unquote(field_name)))]
+        end
 
       false ->
         Args.from_message_fields(message_module, opts)

--- a/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
+++ b/apps/blunt_absinthe/test/blunt/absinthe/mutation_test.exs
@@ -56,6 +56,12 @@ defmodule Blunt.Absinthe.MutationTest do
            } = fields
   end
 
+  test "mutation input argument required" do
+    assert sdl = Absinthe.Schema.to_sdl(Schema)
+
+    assert sdl =~ "updatePersonRequired(input: UpdatePersonRequiredInput!): Person"
+  end
+
   test "derive object" do
     assert %Object{fields: fields} = Absinthe.Schema.lookup_type(Schema, :dog)
     assert %{name: %{type: :string}} = fields

--- a/apps/blunt_absinthe/test/support/schema_types.ex
+++ b/apps/blunt_absinthe/test/support/schema_types.ex
@@ -22,9 +22,11 @@ defmodule Blunt.Absinthe.Test.SchemaTypes do
   end
 
   derive_mutation_input(UpdatePerson, arg_types: [gender: :gender])
+  derive_mutation_input(UpdatePerson, as: :update_person_required, arg_types: [gender: :gender])
 
   object :person_mutations do
     derive_mutation CreatePerson, :person, arg_types: [gender: :gender]
     derive_mutation UpdatePerson, :person, input_object: true
+    derive_mutation UpdatePerson, :person, as: :update_person_required, input_object: true, required: true
   end
 end


### PR DESCRIPTION
https://graphql-rules.com/rules/mutation-input-arg

Add `required: true` option to `derive_mutation` to make `:input` argument required. 

But what effect does `required: true` have if `input_object: false`?

Maybe `input_object: :required` is more cohesive?

Or a config option to mark all `input_object`s required project wide such as when enforced by a linting rule. 
