### PR TITLE
Don't build debug strings when factory debug: false

### DIFF
--- a/apps/blunt_data/lib/blunt/data/factories/factory.ex
+++ b/apps/blunt_data/lib/blunt/data/factories/factory.ex
@@ -139,42 +139,55 @@ defmodule Blunt.Data.Factories.Factory do
   end
 
   def log_value(%__MODULE__{opts: opts}, value, field, lazy, type) do
-    field = ANSI.format([:blue, :bright, to_string(field)])
-    type_prefix = if lazy, do: "lazy ", else: ""
-    debug(value, "#{type_prefix}#{type} #{field}", opts)
+    if Keyword.get(opts, :debug, false) do
+      field = ANSI.format([:blue, :bright, to_string(field)])
+      type_prefix = if lazy, do: "lazy ", else: ""
+      debug(value, "#{type_prefix}#{type} #{field}", opts)
+    else
+      value
+    end
   end
 
   defp debug(%{opts: opts} = factory, :self) do
-    label = ANSI.format([:green, "build"])
-    debug(factory, label, opts)
+    if Keyword.get(opts, :debug, false) do
+      label = ANSI.format([:green, "build"])
+      debug(factory, label, opts)
+    end
+
     factory
   end
 
   defp debug(%{final_message: final_message, opts: opts} = factory, :final_message) do
-    label = ANSI.format([:green, "deliver"])
+    if Keyword.get(opts, :debug, false) do
+      label = ANSI.format([:green, "deliver"])
 
-    final_message =
-      cond do
-        is_map(final_message) ->
-          case Keyword.get(opts, :discarded_data, :hide) do
-            value when value in [:hide, false] ->
-              case Map.get(final_message, :discarded_data) do
-                nil ->
-                  final_message
+      final_message =
+        cond do
+          is_map(final_message) ->
+            case Keyword.get(opts, :discarded_data, :hide) do
+              value when value in [:hide, false] ->
+                case Map.get(final_message, :discarded_data) do
+                  nil ->
+                    final_message
 
-                _ ->
-                  Map.put(final_message, :discarded_data, "configure the factory option 'discarded_data: true' to show")
-              end
+                  _ ->
+                    Map.put(
+                      final_message,
+                      :discarded_data,
+                      "configure the factory option 'discarded_data: true' to show"
+                    )
+                end
 
-            _ ->
-              final_message
-          end
+              _ ->
+                final_message
+            end
 
-        true ->
-          final_message
-      end
+          true ->
+            final_message
+        end
 
-    debug(final_message, label, opts)
+      debug(final_message, label, opts)
+    end
 
     factory
   end


### PR DESCRIPTION
This commit adds earlier `debug: true` checks so `log_value/5` and `debug/2` avoid building messages only to be discarded later.

I was profiling my tests and saw building debug strings took up a bit of the time building factory values. 

```
  Blunt.Data.Factories.Factory.build/1                              66     189.897       0.470  <--
    Blunt.Data.Factories.Factory.build_final_message/1              66     127.517       0.134     
    Blunt.Data.Factories.Factory.evaluate_values/1                  66      25.472       0.264     
    Blunt.Data.Factories.Factory.init_builder/1                     66      23.806       0.266     
    Blunt.Data.Factories.Factory.normalize/1                        66       8.454       0.943     
    Blunt.Data.Factories.Factory.debug/2                           132       4.178       0.529  

  Blunt.Data.Factories.Value.Blunt.Data.Factories.Values.Pro       192      21.930       0.756  <--
    Blunt.Data.Factories.Factory.log_value/5                       175       9.170       0.703     
    Faker.Company.name/0                                            13       3.678       0.065     
```

